### PR TITLE
Fixed import statement in the Initialize app example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The repository authentication data is available in the **.npmrc** file at the ro
 ### Initialize app
 
 ```jsx
-import OBRest from 'obrest';
+import { OBRest } from 'obrest';
 
 OBRest.init("http://localhost:8080");
 ```


### PR DESCRIPTION
index.ts does not export a default so we have to import using curly braces.